### PR TITLE
Update SystemUsage.qml

### DIFF
--- a/services/SystemUsage.qml
+++ b/services/SystemUsage.qml
@@ -142,7 +142,7 @@ Singleton {
         id: gpuTypeCheck
 
         running: true
-        command: ["sh", "-c", "if ls /sys/class/drm/card*/device/gpu_busy_percent 2>/dev/null | grep -q .; then echo GENERIC; elif command -v nvidia-smi >/dev/null; then echo NVIDIA; else echo NONE; fi"]
+        command: ["sh", "-c", "if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then echo NVIDIA; elif ls /sys/class/drm/card*/device/gpu_busy_percent 2>/dev/null | grep -q .; then echo GENERIC; else echo NONE; fi"]
         stdout: StdioCollector {
             onStreamFinished: root.gpuType = text.trim()
         }


### PR DESCRIPTION
Changed line 145 to check for NVIDIA first before GENERIC & added "nvidia-smi -L >/dev/null 2>&1" to add robustness (better compatibility & error redirection). 

Fixes Bug on some systems where iGPU stats will be displayed rather than the stats of the discreet GPU. 

Checking for NVIDIA first is better logic as AMD and INTEL make integrated graphics chips but NVIDIA doesn't. This means that discreet GPU's get checked first and this won't cause issues in cases without discreet graphics or with discreet AMD graphics that use the GENERIC flag.